### PR TITLE
Add from_pixel function, inverse of to_pixel.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -287,6 +287,23 @@ impl<I : Integer> Coordinate<I> {
         Coordinate::nearest_with_offset(spacing, v)
     }
 
+    /// Find the hex containing a pixel. The origin of the pixel coordinates
+    /// is the center of the hex at (0,0) in hex coordinates.
+    pub fn from_pixel(x: f32, y: f32, spacing: Spacing) -> Coordinate<I> {
+        match spacing {
+            Spacing::PointyTop(size) => {
+                let q = (x * 3f32.sqrt()/3f32 - y / 3f32) / size;
+                let r = y * 2f32/3f32 / size;
+                return Coordinate::nearest(q, -r -q);
+            },
+            Spacing::FlatTop(size) => {
+                let q = x * 2f32/3f32 / size;
+                let r = (-x / 3f32 + 3f32.sqrt()/3f32 * y) / size;
+                return Coordinate::nearest(q, -r -q);
+            }
+        }
+    }
+
     /// Convert integer pixel coordinates `v` using `spacing` to nearest coordinate that has both
     /// integer pixel coordinates lower or equal to `v`. Also return offset (in integer pixels)
     /// from that coordinate.

--- a/src/test.rs
+++ b/src/test.rs
@@ -209,6 +209,20 @@ fn simple_to_pixel() {
 #[test]
 fn simple_from_pixel() {
     for &spacing in [
+        Spacing::PointyTop(30.0),
+        Spacing::PointyTop(-40.0),
+        Spacing::FlatTop(100.0)
+    ].iter() {
+        with_test_points(|c : Coordinate| {
+            let (x, y) = c.to_pixel(spacing);
+            assert_eq!(c, Coordinate::from_pixel(x, y, spacing));
+        });
+    }
+}
+
+#[test]
+fn simple_from_pixel_integer() {
+    for &spacing in [
         IntegerSpacing::PointyTop(2, 1),
         IntegerSpacing::PointyTop(4, 6),
         IntegerSpacing::FlatTop(3, 2),


### PR DESCRIPTION
Useful for going from non-integer based pixel coordinates to hex
coordinates.

I also renamed the existing test to simple_from_pixel_integer to prevent confusion.

[Example of the new function can be seen here. (Function name is axial_pixel_to_hex in the example).](https://github.com/echochamber/rust_hex_grid/blob/master/src/main.rs#L52)