### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rust:
   - stable
   - beta
   - nightly
+cache: cargo
 matrix:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ rust:
   - stable
   - beta
   - nightly
+matrix:
+  allow_failures:
+    - rust: nightly
 env:
   - DOCS_DEFAULT_MODULE=hex2d
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.0.0
+  - stable
   - beta
   - nightly
 env:


### PR DESCRIPTION
Updating .travis.yml.

If the doc link is going to be docs.rs, then the deploy to github page part should be dropped I think. The only slight problem is then there is no documentation for the master branch, only releases. If it's going to be kept, then it should be updated: https://github.com/rardiol/hex2d-rs/commit/14452d06815fb65cc5c38e7788fae37f4bdc600d