### PR TITLE
Iterators for Range, Ring and line_to

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,14 +458,21 @@ impl<I : Integer> Coordinate<I> {
         }
     }
 
+    /// Iterator over each coordinate in straight line from `self` to `dest`
     pub fn line_to_iter(&self, dest: Coordinate<I>) -> LineTo<I> {
         LineTo(self.line_to_iter_gen(dest))
     }
 
+    /// Iterator over each coordinate in straight line from `self` to `dest`
+    ///
+    /// Skip points on the border of two tiles
     pub fn line_to_lossy_iter(&self, dest: Coordinate<I>) -> LineToLossy<I> {
         LineToLossy(self.line_to_iter_gen(dest))
     }
 
+    /// Iterator over each coordinate in straight line from `self` to `dest`
+    ///
+    /// On edge condition the pair contains different members, otherwise it's the same.
     pub fn line_to_with_edge_detection_iter(&self, dest: Coordinate<I>) -> LineToWithEdgeDetection<I> {
         LineToWithEdgeDetection(self.line_to_iter_gen(dest))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1207,7 +1207,7 @@ impl<
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (0, self.0.size_hint().1)
+        (self.0.size_hint().0/2, self.0.size_hint().1)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -785,6 +785,7 @@ impl<I : Integer> Coordinate<I> {
             x: -r,
             y: max(-r, -(-r)-r),
             r,
+            counter: 0,
         }
     }
 
@@ -1008,6 +1009,7 @@ pub struct Range<I: Integer> {
     x: I,
     y: I,
     r: I,
+    counter: usize,
 }
 
 impl<
@@ -1037,19 +1039,15 @@ impl<
             y: self.source.y + self.y,
         });
         self.y += One::one();
+        self.counter += 1;
         ret
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let mut counter: usize = Zero::zero();
-        for x in range_inclusive(-self.r, self.r) {
-            for _ in range_inclusive(max(-self.r, -x-self.r), min(self.r, -x+self.r)) {
-                counter += 1;
-            }
-        }
         let rc = (if self.r < Zero::zero() { I::one()-self.r } else { self.r }).to_usize().unwrap();
         let total_size = 3*(rc+rc*rc)+1;
-        (total_size-counter, Some(total_size-counter))
+        let current_size = total_size-self.counter;
+        (current_size, Some(current_size))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,6 +462,10 @@ impl<I : Integer> Coordinate<I> {
         LineTo(self.line_to_iter_gen(dest))
     }
 
+    pub fn line_to_lossy_iter(&self, dest: Coordinate<I>) -> LineToLossy<I> {
+        LineToLossy(self.line_to_iter_gen(dest))
+    }
+
     /// Execute `f` for each coordinate in straight line from `self` to `dest`
     pub fn for_each_in_line_to<F>(&self, dest : Coordinate<I>, mut f : F)
         where
@@ -919,6 +923,24 @@ impl<
     }
 }
 
+pub struct LineToLossy<I: Integer> (LineToGen<I>);
+
+impl<
+        I: num::Integer
+            + num::Signed
+            + std::marker::Copy
+            + num::NumCast
+            + num::FromPrimitive
+            + num::CheckedAdd
+            + std::marker::Copy
+            + std::ops::AddAssign,
+    > Iterator for LineToLossy<I>
+{
+    type Item = Coordinate<I>;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().and_then(|(x, y)| Coordinate::nearest_lossy(x, y))
+    }
+}
 impl<I : Integer> From<(I, I)> for Coordinate<I> {
     fn from(xy: (I, I)) -> Self {
         let (x, y) = xy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,8 @@ use num::{Float, One, Zero};
 use num::iter::range_inclusive;
 use std::ops::{Add, Sub, Neg};
 use std::cmp::{max, min};
-use std::convert::{Into, From, TryInto};
+use std::convert::{Into, From, TryInto, TryFrom};
+use std::fmt::Debug;
 use std::f64::consts::PI;
 use std::iter;
 
@@ -1068,6 +1069,9 @@ impl<
             + std::marker::Copy
             + std::ops::AddAssign,
     > Iterator for LineToGen<I>
+where
+    usize: TryFrom<I>,
+    <usize as TryFrom<I>>::Error: Debug,
 {
     type Item = (f32, f32);
 
@@ -1091,6 +1095,13 @@ impl<
         self.i += One::one();
         Some((x, y))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let origin = Coordinate::<I>::nearest(self.ax, self.ay);
+        let dest = Coordinate::nearest(self.bx, self.by);
+        let total_size = origin.distance(dest) + One::one();
+        (0, Some(total_size.try_into().unwrap()))
+    }
 }
 
 #[derive(Clone, PartialEq, Debug, PartialOrd)]
@@ -1108,6 +1119,9 @@ impl<
             + std::marker::Copy
             + std::ops::AddAssign,
     > Iterator for LineTo<I>
+where
+    usize: std::convert::TryFrom<I>,
+    <usize as TryFrom<I>>::Error: Debug,
 {
     type Item = Coordinate<I>;
     fn next(&mut self) -> Option<Self::Item> {
@@ -1134,6 +1148,9 @@ impl<
             + std::marker::Copy
             + std::ops::AddAssign,
     > Iterator for LineToLossy<I>
+where
+    usize: std::convert::TryFrom<I>,
+    <usize as TryFrom<I>>::Error: Debug,
 {
     type Item = Coordinate<I>;
     fn next(&mut self) -> Option<Self::Item> {
@@ -1167,6 +1184,9 @@ impl<
             + std::marker::Copy
             + std::ops::AddAssign,
     > Iterator for LineToWithEdgeDetection<I>
+where
+    usize: std::convert::TryFrom<I>,
+    <usize as TryFrom<I>>::Error: Debug,
 {
     type Item = (Coordinate<I>, Coordinate<I>);
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1128,6 +1128,17 @@ impl<
         + std::marker::Copy
         + num::NumCast
         + num::FromPrimitive
+        + num::CheckedAdd
+        + std::marker::Copy
+        + std::ops::AddAssign,
+    > iter::FusedIterator for LineToGen<I> {}
+
+impl<
+        I: num::Integer
+        + num::Signed
+        + std::marker::Copy
+        + num::NumCast
+        + num::FromPrimitive
         + num::ToPrimitive
         + num::CheckedAdd
         + std::marker::Copy
@@ -1162,6 +1173,17 @@ impl<
         self.0.size_hint()
     }
 }
+
+impl<
+        I: num::Integer
+        + num::Signed
+        + std::marker::Copy
+        + num::NumCast
+        + num::FromPrimitive
+        + num::CheckedAdd
+        + std::marker::Copy
+        + std::ops::AddAssign,
+    > iter::FusedIterator for LineTo<I> {}
 
 impl<
         I: num::Integer
@@ -1211,6 +1233,17 @@ impl<
     }
 }
 
+impl<
+        I: num::Integer
+        + num::Signed
+        + std::marker::Copy
+        + num::NumCast
+        + num::FromPrimitive
+        + num::CheckedAdd
+        + std::marker::Copy
+        + std::ops::AddAssign,
+    > iter::FusedIterator for LineToLossy<I> {}
+
 #[derive(Clone, PartialEq, Debug, PartialOrd)]
 #[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]
 /// An iterator over an a line of Coordinates, with edge detection
@@ -1240,6 +1273,17 @@ impl<
         self.0.size_hint()
     }
 }
+
+impl<
+        I: num::Integer
+        + num::Signed
+        + std::marker::Copy
+        + num::NumCast
+        + num::FromPrimitive
+        + num::CheckedAdd
+        + std::marker::Copy
+        + std::ops::AddAssign,
+    > iter::FusedIterator for LineToWithEdgeDetection<I> {}
 
 impl<
         I: num::Integer

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -776,6 +776,16 @@ impl<I : Integer> Coordinate<I> {
             / num::FromPrimitive::from_i8(2).unwrap()
     }
 
+    /// An iterator over all coordinates in radius `r`
+    pub fn range_iter(&self, r : I) -> Range<I> {
+        Range{
+            source: *self,
+            x: -r,
+            y: max(-r, -(-r)-r),
+            r,
+        }
+    }
+
     /// All coordinates in radius `r`
     pub fn range(&self, r : I) -> Vec<Coordinate<I>>
     where
@@ -870,6 +880,48 @@ impl<I : Integer> Coordinate<I> {
         }
     }
 }
+
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd)]
+#[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]
+/// Iterator over an range
+pub struct Range<I: Integer> {
+    source: Coordinate<I>,
+    x: I,
+    y: I,
+    r: I,
+}
+
+impl<
+        I: num::Integer
+        + num::Signed
+        + std::marker::Copy
+        + num::NumCast
+        + num::FromPrimitive
+        + num::CheckedAdd
+        + std::marker::Copy
+        + std::ops::AddAssign,
+    > Iterator for Range<I>
+{
+    type Item = Coordinate<I>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.y > min(self.r, -self.x+self.r) {
+            self.x += One::one();
+            if self.x > self.r {
+                return None
+            }
+            self.y = max(-self.r, -self.x-self.r);
+        }
+
+        let ret = Some(Coordinate{
+            x: self.source.x + self.x,
+            y: self.source.y + self.y,
+        });
+        self.y += One::one();
+        ret
+    }
+}
+
 
 #[derive(Clone, PartialEq, Debug, PartialOrd)]
 #[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1027,10 +1027,10 @@ impl<
 
     fn next(&mut self) -> Option<Self::Item> {
         if self.y > min(self.r, -self.x+self.r) {
-            self.x += One::one();
-            if self.x > self.r {
+            if self.x >= self.r {
                 return None
             }
+            self.x += One::one();
             self.y = max(-self.r, -self.x-self.r);
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -964,6 +964,10 @@ impl<
         ret
 
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, Some(if self.r == 0 { 1 } else if self.r < 0 { (self.r*-6) as usize } else { (self.r*6) as usize }))
+    }
 }
 
 impl<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -579,6 +579,10 @@ impl<I : Integer> Coordinate<I> {
     }
 
     /// Construct a straight line to a `dest`
+    #[deprecated(
+        since = "0.4.0",
+        note = "Please use line_to_iter and collect instead"
+    )]
     pub fn line_to(&self, dest : Coordinate<I>) -> Vec<Coordinate<I>>
     where
         for <'a> &'a I: Add<&'a I, Output = I>
@@ -595,6 +599,10 @@ impl<I : Integer> Coordinate<I> {
     /// Construct a straight line to a `dest`
     ///
     /// Skip points on the border of two tiles
+    #[deprecated(
+        since = "0.4.0",
+        note = "Please use line_to_lossy_iter and collect instead"
+    )]
     pub fn line_to_lossy(&self, dest : Coordinate<I>) -> Vec<Coordinate<I>>
     where
         for <'a> &'a I: Add<&'a I, Output = I>
@@ -609,6 +617,10 @@ impl<I : Integer> Coordinate<I> {
     }
 
     /// Construct a straight line to a `dest`
+    #[deprecated(
+        since = "0.4.0",
+        note = "Please use line_to_with_edge_detection_iter and collect instead"
+    )]
     pub fn line_to_with_edge_detection(&self, dest : Coordinate<I>) -> Vec<(Coordinate<I>, Coordinate<I>)>
     where
         for <'a> &'a I: Add<&'a I, Output = I>
@@ -801,6 +813,10 @@ impl<I : Integer> Coordinate<I> {
     }
 
     /// All coordinates in radius `r`
+    #[deprecated(
+        since = "0.4.0",
+        note = "Please use range_iter and collect instead"
+    )]
     pub fn range(&self, r : I) -> Vec<Coordinate<I>>
     where
         for <'a> &'a I: Add<&'a I, Output = I>
@@ -860,6 +876,10 @@ impl<I : Integer> Coordinate<I> {
     ///     }
     /// }
     /// ```
+    #[deprecated(
+        since = "0.4.0",
+        note = "Please use ring_iter and collect instead"
+    )]
     pub fn ring(&self, r : i32, s : Spin) -> Vec<Coordinate<I>> {
         let mut res = Vec::with_capacity(if r == 0 { 1 } else if r < 0 { (r*-6) as usize } else { (r*6) as usize });
         self.for_each_in_ring(r, s, |c| res.push(c));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,7 @@ use std::ops::{Add, Sub, Neg};
 use std::cmp::{max, min};
 use std::convert::{Into, From};
 use std::f64::consts::PI;
+use std::iter;
 
 pub use Direction::*;
 pub use Angle::*;
@@ -964,6 +965,19 @@ impl<
 
     }
 }
+
+impl<
+        I: num::Integer
+        + num::Signed
+        + std::marker::Copy
+        + num::NumCast
+        + num::FromPrimitive
+        + num::CheckedAdd
+        + std::marker::Copy
+        + std::ops::AddAssign,
+    > iter::FusedIterator for Ring<I> {}
+
+
 
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug, Ord, PartialOrd)]
 #[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,6 @@ use num::iter::range_inclusive;
 use std::ops::{Add, Sub, Neg};
 use std::cmp::{max, min};
 use std::convert::{Into, From, TryInto};
-use std::fmt::Debug;
 use std::f64::consts::PI;
 use std::iter;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -479,6 +479,10 @@ impl<I : Integer> Coordinate<I> {
     }
 
     /// Execute `f` for each coordinate in straight line from `self` to `dest`
+    #[deprecated(
+        since = "0.4.0",
+        note = "Please use line_to_iter instead"
+    )]
     pub fn for_each_in_line_to<F>(&self, dest : Coordinate<I>, mut f : F)
         where
         F : FnMut(Coordinate<I>),
@@ -508,6 +512,10 @@ impl<I : Integer> Coordinate<I> {
     /// Execute `f` for each coordinate in straight line from `self` to `dest`
     ///
     /// Skip points on the border of two tiles
+    #[deprecated(
+        since = "0.4.0",
+        note = "Please use line_to_lossy_iter instead"
+    )]
     pub fn for_each_in_line_to_lossy<F>(&self, dest : Coordinate<I>, mut f : F)
         where
         F : FnMut(Coordinate<I>),
@@ -539,6 +547,10 @@ impl<I : Integer> Coordinate<I> {
     /// Execute `f` for pairs of coordinates in straight line from `self` to `dest`
     ///
     /// On edge condition the pair contains different members, otherwise it's the same.
+    #[deprecated(
+        since = "0.4.0",
+        note = "Please use line_to_with_edge_detection_iter instead"
+    )]
     pub fn for_each_in_line_to_with_edge_detection<F>(&self, dest : Coordinate<I>, mut f : F)
         where
         F : FnMut((Coordinate<I>, Coordinate<I>)),
@@ -802,6 +814,10 @@ impl<I : Integer> Coordinate<I> {
     }
 
     /// Execute `f` for all coordinates in radius `r`
+    #[deprecated(
+        since = "0.4.0",
+        note = "Please use range_iter instead"
+    )]
     pub fn for_each_in_range<F>(&self, r : I, mut f : F)
         where
         F : FnMut(Coordinate<I>),
@@ -854,6 +870,10 @@ impl<I : Integer> Coordinate<I> {
     /// Call `f` for each coordinate in a ring
     ///
     /// See `ring` for a ring description.
+    #[deprecated(
+        since = "0.4.0",
+        note = "Please use ring_iter instead"
+    )]
     pub fn for_each_in_ring<F>(&self, r : i32, s : Spin, mut f : F)
         where F : FnMut(Coordinate<I>) {
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1041,10 +1041,30 @@ impl<
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
+        let mut counter: usize = Zero::zero();
+        for x in range_inclusive(-self.r, self.r) {
+            for _ in range_inclusive(max(-self.r, -x-self.r), min(self.r, -x+self.r)) {
+                counter += 1;
+            }
+        }
         let rc = (if self.r < Zero::zero() { I::one()-self.r } else { self.r }).to_usize().unwrap();
-        (0, Some(3*(rc+rc*rc)+1))
+        let total_size = 3*(rc+rc*rc)+1;
+        (total_size-counter, Some(total_size-counter))
     }
 }
+
+impl<
+        I: num::Integer
+        + num::Signed
+        + std::marker::Copy
+        + num::NumCast
+        + num::FromPrimitive
+        + num::CheckedAdd
+        + std::marker::Copy
+        + std::ops::AddAssign,
+    >
+    iter::ExactSizeIterator for Range<I>
+{}
 
 
 #[derive(Clone, PartialEq, Debug, PartialOrd)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -466,6 +466,10 @@ impl<I : Integer> Coordinate<I> {
         LineToLossy(self.line_to_iter_gen(dest))
     }
 
+    pub fn line_to_with_edge_detection_iter(&self, dest: Coordinate<I>) -> LineToWithEdgeDetection<I> {
+        LineToWithEdgeDetection(self.line_to_iter_gen(dest))
+    }
+
     /// Execute `f` for each coordinate in straight line from `self` to `dest`
     pub fn for_each_in_line_to<F>(&self, dest : Coordinate<I>, mut f : F)
         where
@@ -954,6 +958,31 @@ impl<
         }
     }
 }
+
+#[derive(Clone, PartialEq, Debug, PartialOrd)]
+#[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]
+pub struct LineToWithEdgeDetection<I: Integer> (LineToGen<I>);
+
+impl<
+        I: num::Integer
+            + num::Signed
+            + std::marker::Copy
+            + num::NumCast
+            + num::FromPrimitive
+            + num::CheckedAdd
+            + std::marker::Copy
+            + std::ops::AddAssign,
+    > Iterator for LineToWithEdgeDetection<I>
+{
+    type Item = (Coordinate<I>, Coordinate<I>);
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(x, y)| (
+            Coordinate::nearest(x + 0.000001, y + 0.000001),
+            Coordinate::nearest(x - 0.000001, y - 0.000001)
+        ))
+    }
+}
+
 impl<I : Integer> From<(I, I)> for Coordinate<I> {
     fn from(xy: (I, I)) -> Self {
         let (x, y) = xy;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1113,6 +1113,10 @@ impl<
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|(x, y)| Coordinate::nearest(x, y))
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
 }
 
 #[derive(Clone, PartialEq, Debug, PartialOrd)]
@@ -1142,6 +1146,10 @@ impl<
             }
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, self.0.size_hint().1)
+    }
 }
 
 #[derive(Clone, PartialEq, Debug, PartialOrd)]
@@ -1166,6 +1174,10 @@ impl<
             Coordinate::nearest(x + 0.000001, y + 0.000001),
             Coordinate::nearest(x - 0.000001, y - 0.000001)
         ))
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -938,7 +938,14 @@ impl<
 {
     type Item = Coordinate<I>;
     fn next(&mut self) -> Option<Self::Item> {
-        self.0.next().and_then(|(x, y)| Coordinate::nearest_lossy(x, y))
+        loop {
+            let c = self.0.next().map(|(x, y)| Coordinate::nearest_lossy(x, y));
+            match c {
+                Some(c@Some(_)) => return c,
+                Some(None) => continue,
+                None => return None,
+            }
+        }
     }
 }
 impl<I : Integer> From<(I, I)> for Coordinate<I> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1060,6 +1060,17 @@ impl<
         + num::CheckedAdd
         + std::marker::Copy
         + std::ops::AddAssign,
+    > iter::FusedIterator for Range<I> {}
+
+impl<
+        I: num::Integer
+        + num::Signed
+        + std::marker::Copy
+        + num::NumCast
+        + num::FromPrimitive
+        + num::CheckedAdd
+        + std::marker::Copy
+        + std::ops::AddAssign,
     >
     iter::ExactSizeIterator for Range<I>
 {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -860,6 +860,8 @@ impl<I : Integer> Coordinate<I> {
     }
 }
 
+#[derive(Clone, PartialEq, Debug, PartialOrd)]
+#[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]
 struct LineToGen<I: Integer> {
     ax: f32,
     ay: f32,
@@ -904,6 +906,8 @@ impl<
     }
 }
 
+#[derive(Clone, PartialEq, Debug, PartialOrd)]
+#[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]
 pub struct LineTo<I: Integer> (LineToGen<I>);
 
 impl<
@@ -923,6 +927,8 @@ impl<
     }
 }
 
+#[derive(Clone, PartialEq, Debug, PartialOrd)]
+#[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]
 pub struct LineToLossy<I: Integer> (LineToGen<I>);
 
 impl<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ use num::{Float, One, Zero};
 use num::iter::range_inclusive;
 use std::ops::{Add, Sub, Neg};
 use std::cmp::{max, min};
-use std::convert::{Into, From, TryInto, TryFrom};
+use std::convert::{Into, From, TryInto};
 use std::fmt::Debug;
 use std::f64::consts::PI;
 use std::iter;
@@ -1083,13 +1083,11 @@ impl<
             + std::marker::Copy
             + num::NumCast
             + num::FromPrimitive
+            + num::ToPrimitive
             + num::CheckedAdd
             + std::marker::Copy
             + std::ops::AddAssign,
     > Iterator for LineToGen<I>
-where
-    usize: TryFrom<I>,
-    <usize as TryFrom<I>>::Error: Debug,
 {
     type Item = (f32, f32);
 
@@ -1119,7 +1117,7 @@ where
         let dest = Coordinate::nearest(self.bx, self.by);
         let total_size = origin.distance(dest) + One::one();
         let len = total_size-self.i;
-        let len = len.try_into().unwrap();
+        let len = len.to_usize().unwrap();
         (len, Some(len))
     }
 }
@@ -1130,14 +1128,12 @@ impl<
         + std::marker::Copy
         + num::NumCast
         + num::FromPrimitive
+        + num::ToPrimitive
         + num::CheckedAdd
         + std::marker::Copy
         + std::ops::AddAssign,
     >
     iter::ExactSizeIterator for LineToGen<I>
-where
-    usize: TryFrom<I>,
-<usize as TryFrom<I>>::Error: Debug,
 {}
 
 #[derive(Clone, PartialEq, Debug, PartialOrd)]
@@ -1151,13 +1147,11 @@ impl<
             + std::marker::Copy
             + num::NumCast
             + num::FromPrimitive
+            + num::ToPrimitive
             + num::CheckedAdd
             + std::marker::Copy
             + std::ops::AddAssign,
     > Iterator for LineTo<I>
-where
-    usize: std::convert::TryFrom<I>,
-    <usize as TryFrom<I>>::Error: Debug,
 {
     type Item = Coordinate<I>;
     fn next(&mut self) -> Option<Self::Item> {
@@ -1175,14 +1169,12 @@ impl<
         + std::marker::Copy
         + num::NumCast
         + num::FromPrimitive
+        + num::ToPrimitive
         + num::CheckedAdd
         + std::marker::Copy
         + std::ops::AddAssign,
     >
     iter::ExactSizeIterator for LineTo<I>
-where
-    usize: TryFrom<I>,
-<usize as TryFrom<I>>::Error: Debug,
 {}
 
 #[derive(Clone, PartialEq, Debug, PartialOrd)]
@@ -1196,13 +1188,11 @@ impl<
             + std::marker::Copy
             + num::NumCast
             + num::FromPrimitive
+            + num::ToPrimitive
             + num::CheckedAdd
             + std::marker::Copy
             + std::ops::AddAssign,
     > Iterator for LineToLossy<I>
-where
-    usize: std::convert::TryFrom<I>,
-    <usize as TryFrom<I>>::Error: Debug,
 {
     type Item = Coordinate<I>;
     fn next(&mut self) -> Option<Self::Item> {
@@ -1232,13 +1222,11 @@ impl<
             + std::marker::Copy
             + num::NumCast
             + num::FromPrimitive
+            + num::ToPrimitive
             + num::CheckedAdd
             + std::marker::Copy
             + std::ops::AddAssign,
     > Iterator for LineToWithEdgeDetection<I>
-where
-    usize: std::convert::TryFrom<I>,
-    <usize as TryFrom<I>>::Error: Debug,
 {
     type Item = (Coordinate<I>, Coordinate<I>);
     fn next(&mut self) -> Option<Self::Item> {
@@ -1259,14 +1247,12 @@ impl<
         + std::marker::Copy
         + num::NumCast
         + num::FromPrimitive
+        + num::ToPrimitive
         + num::CheckedAdd
         + std::marker::Copy
         + std::ops::AddAssign,
     >
     iter::ExactSizeIterator for LineToWithEdgeDetection<I>
-where
-    usize: TryFrom<I>,
-<usize as TryFrom<I>>::Error: Debug,
 {}
 
 impl<I : Integer> From<(I, I)> for Coordinate<I> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -873,6 +873,7 @@ impl<I : Integer> Coordinate<I> {
 
 #[derive(Clone, PartialEq, Debug, PartialOrd)]
 #[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]
+/// Genertic iterator over a line return x, y values
 struct LineToGen<I: Integer> {
     ax: f32,
     ay: f32,
@@ -919,6 +920,7 @@ impl<
 
 #[derive(Clone, PartialEq, Debug, PartialOrd)]
 #[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]
+/// An iterator over an a line of Coordinates
 pub struct LineTo<I: Integer> (LineToGen<I>);
 
 impl<
@@ -940,6 +942,7 @@ impl<
 
 #[derive(Clone, PartialEq, Debug, PartialOrd)]
 #[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]
+/// An iterator over an a line of Coordinates, using a lossy algorithm
 pub struct LineToLossy<I: Integer> (LineToGen<I>);
 
 impl<
@@ -968,6 +971,7 @@ impl<
 
 #[derive(Clone, PartialEq, Debug, PartialOrd)]
 #[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]
+/// An iterator over an a line of Coordinates, with edge detection
 pub struct LineToWithEdgeDetection<I: Integer> (LineToGen<I>);
 
 impl<

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1100,9 +1100,27 @@ where
         let origin = Coordinate::<I>::nearest(self.ax, self.ay);
         let dest = Coordinate::nearest(self.bx, self.by);
         let total_size = origin.distance(dest) + One::one();
-        (0, Some(total_size.try_into().unwrap()))
+        let len = total_size-self.i;
+        let len = len.try_into().unwrap();
+        (len, Some(len))
     }
 }
+
+impl<
+        I: num::Integer
+        + num::Signed
+        + std::marker::Copy
+        + num::NumCast
+        + num::FromPrimitive
+        + num::CheckedAdd
+        + std::marker::Copy
+        + std::ops::AddAssign,
+    >
+    iter::ExactSizeIterator for LineToGen<I>
+where
+    usize: TryFrom<I>,
+<usize as TryFrom<I>>::Error: Debug,
+{}
 
 #[derive(Clone, PartialEq, Debug, PartialOrd)]
 #[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]
@@ -1132,6 +1150,22 @@ where
         self.0.size_hint()
     }
 }
+
+impl<
+        I: num::Integer
+        + num::Signed
+        + std::marker::Copy
+        + num::NumCast
+        + num::FromPrimitive
+        + num::CheckedAdd
+        + std::marker::Copy
+        + std::ops::AddAssign,
+    >
+    iter::ExactSizeIterator for LineTo<I>
+where
+    usize: TryFrom<I>,
+<usize as TryFrom<I>>::Error: Debug,
+{}
 
 #[derive(Clone, PartialEq, Debug, PartialOrd)]
 #[cfg_attr(feature="serde-serde", derive(Serialize, Deserialize))]
@@ -1200,6 +1234,22 @@ where
         self.0.size_hint()
     }
 }
+
+impl<
+        I: num::Integer
+        + num::Signed
+        + std::marker::Copy
+        + num::NumCast
+        + num::FromPrimitive
+        + num::CheckedAdd
+        + std::marker::Copy
+        + std::ops::AddAssign,
+    >
+    iter::ExactSizeIterator for LineToWithEdgeDetection<I>
+where
+    usize: TryFrom<I>,
+<usize as TryFrom<I>>::Error: Debug,
+{}
 
 impl<I : Integer> From<(I, I)> for Coordinate<I> {
     fn from(xy: (I, I)) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1022,6 +1022,11 @@ impl<
         self.y += One::one();
         ret
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let rc = (if self.r < Zero::zero() { I::one()-self.r } else { self.r }).to_usize().unwrap();
+        (0, Some(3*(rc+rc*rc)+1))
+    }
 }
 
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -372,3 +372,16 @@ fn range_iter() {
         }
     });
 }
+
+#[test]
+fn ring_iter() {
+    with_test_points(|c : Coordinate| {
+        for i in &[0, 1, 2, 4, 10, 40]{
+            for direction in &ALL_DIRECTIONS {
+                for spin in &[CW(*direction), CCW(*direction)] {
+                    assert_eq!(c.ring(*i, *spin), c.ring_iter(*i, *spin).collect::<Vec<_>>());
+                }
+            }
+        }
+    });
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -359,7 +359,19 @@ fn simple_line_to() {
 fn line_to_iter() {
     with_pair_test_points(|a: Coordinate, b: Coordinate| {
         assert_eq!(a.line_to(b), a.line_to_iter(b).collect::<Vec<_>>());
+    });
+}
+
+#[test]
+fn line_to_lossy_iter() {
+    with_pair_test_points(|a: Coordinate, b: Coordinate| {
         assert_eq!(a.line_to_lossy(b), a.line_to_lossy_iter(b).collect::<Vec<_>>());
+    });
+}
+
+#[test]
+fn line_to_with_edge_detection_iter() {
+    with_pair_test_points(|a: Coordinate, b: Coordinate| {
         assert_eq!(a.line_to_with_edge_detection(b), a.line_to_with_edge_detection_iter(b).collect::<Vec<_>>());
     });
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -368,7 +368,10 @@ fn line_to_iter() {
 fn range_iter() {
     with_test_points(|c : Coordinate| {
         for i in &[0, 1, 2, 4, 10, 40]{
-            assert_eq!(c.range(*i), c.range_iter(*i).collect::<Vec<_>>());
+            let original = c.range(*i);
+            let iter = c.range_iter(*i);
+            assert_eq!(original.len(), iter.size_hint().1.unwrap());
+            assert_eq!(original, iter.collect::<Vec<_>>());
         }
     });
 }
@@ -379,7 +382,10 @@ fn ring_iter() {
         for i in &[0, 1, 2, 4, 10, 40]{
             for direction in &ALL_DIRECTIONS {
                 for spin in &[CW(*direction), CCW(*direction)] {
-                    assert_eq!(c.ring(*i, *spin), c.ring_iter(*i, *spin).collect::<Vec<_>>());
+                    let original = c.ring(*i, *spin);
+                    let iter = c.ring_iter(*i, *spin);
+                    assert_eq!(original.len(), iter.size_hint().1.unwrap());
+                    assert_eq!(original, iter.collect::<Vec<_>>());
                 }
             }
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -363,3 +363,12 @@ fn line_to_iter() {
         assert_eq!(a.line_to_with_edge_detection(b), a.line_to_with_edge_detection_iter(b).collect::<Vec<_>>());
     });
 }
+
+#[test]
+fn range_iter() {
+    with_test_points(|c : Coordinate| {
+        for i in &[0, 1, 2, 4, 10, 40]{
+            assert_eq!(c.range(*i), c.range_iter(*i).collect::<Vec<_>>());
+        }
+    });
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -356,6 +356,7 @@ fn simple_line_to() {
 }
 
 // Tests an iterator with size_hint against a Vec
+// Also tests for fused
 fn test_iter<T: std::cmp::PartialEq + std::fmt::Debug>(original: Vec<T>, mut iter: impl Iterator<Item=T>) {
     assert!(original.len() <= iter.size_hint().1.unwrap());
     assert!(original.len() >= iter.size_hint().0);
@@ -369,9 +370,14 @@ fn test_iter<T: std::cmp::PartialEq + std::fmt::Debug>(original: Vec<T>, mut ite
         vec.push(el);
     }
     assert_eq!(original, vec);
+
+    for _ in 0..10000 {
+        assert!(iter.next().is_none());
+    }
 }
 
 // Tests an ExactSizeIterator against a Vec
+// Also tests for fused
 fn test_iter_exact<T: std::cmp::PartialEq + std::fmt::Debug>(original: Vec<T>, mut iter: impl ExactSizeIterator<Item=T>) {
     assert_eq!(original.len(), iter.len());
     let mut vec = Vec::new();
@@ -382,6 +388,10 @@ fn test_iter_exact<T: std::cmp::PartialEq + std::fmt::Debug>(original: Vec<T>, m
         vec.push(el);
     }
     assert_eq!(original, vec);
+
+    for _ in 0..10000 {
+        assert!(iter.next().is_none());
+    }
 }
 
 #[test]

--- a/src/test.rs
+++ b/src/test.rs
@@ -355,13 +355,15 @@ fn simple_line_to() {
     });
 }
 
+fn test_iter<T: std::cmp::PartialEq + std::fmt::Debug>(original: Vec<T>, iter: impl Iterator<Item=T>) {
+    assert_eq!(original.len(), iter.size_hint().1.unwrap());
+    assert_eq!(original, iter.collect::<Vec<_>>());
+}
+
 #[test]
 fn line_to_iter() {
     with_pair_test_points(|a: Coordinate, b: Coordinate| {
-        let original = a.line_to(b);
-        let iter = a.line_to_iter(b);
-        assert_eq!(original.len(), iter.size_hint().1.unwrap());
-        assert_eq!(original, iter.collect::<Vec<_>>());
+        test_iter(a.line_to(b), a.line_to_iter(b));
     });
 }
 
@@ -378,10 +380,7 @@ fn line_to_lossy_iter() {
 #[test]
 fn line_to_with_edge_detection_iter() {
     with_pair_test_points(|a: Coordinate, b: Coordinate| {
-        let original = a.line_to_with_edge_detection(b);
-        let iter = a.line_to_with_edge_detection_iter(b);
-        assert_eq!(original.len(), iter.size_hint().1.unwrap());
-        assert_eq!(original, iter.collect::<Vec<_>>());
+        test_iter(a.line_to_with_edge_detection(b), a.line_to_with_edge_detection_iter(b));
     });
 }
 
@@ -389,10 +388,7 @@ fn line_to_with_edge_detection_iter() {
 fn range_iter() {
     with_test_points(|c : Coordinate| {
         for i in &[0, 1, 2, 4, 10, 40]{
-            let original = c.range(*i);
-            let iter = c.range_iter(*i);
-            assert_eq!(original.len(), iter.size_hint().1.unwrap());
-            assert_eq!(original, iter.collect::<Vec<_>>());
+            test_iter(c.range(*i), c.range_iter(*i));
         }
     });
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -14,6 +14,21 @@ fn with_test_points<F : Fn(Coordinate) -> ()>(f : F) {
     }
 }
 
+fn with_pair_test_points<F: Fn(Coordinate, Coordinate) -> ()>(f: F) {
+    let offs = [-2i32, -1, 0, 1, 2, 1000, -1000, 1001, -1001];
+    for &ax in offs.iter() {
+        for &ay in offs.iter() {
+            let a = Coordinate::new(ax, ay);
+            for &bx in offs.iter() {
+                for &by in offs.iter() {
+                    let b = Coordinate::new(bx, by);
+                    f(a, b)
+                }
+            }
+        }
+    }
+}
+
 #[test]
 fn coord_add_and_sub() {
     let a = Coordinate::new(-1, 2);
@@ -340,3 +355,9 @@ fn simple_line_to() {
     });
 }
 
+#[test]
+fn line_to_iter() {
+    with_pair_test_points(|a: Coordinate, b: Coordinate| {
+        assert_eq!(a.line_to(b), a.line_to_iter(b).collect::<Vec<_>>());
+    });
+}

--- a/src/test.rs
+++ b/src/test.rs
@@ -383,9 +383,16 @@ fn ring_iter() {
             for direction in &ALL_DIRECTIONS {
                 for spin in &[CW(*direction), CCW(*direction)] {
                     let original = c.ring(*i, *spin);
-                    let iter = c.ring_iter(*i, *spin);
-                    assert_eq!(original.len(), iter.size_hint().1.unwrap());
-                    assert_eq!(original, iter.collect::<Vec<_>>());
+                    let mut iter = c.ring_iter(*i, *spin);
+                    assert_eq!(original.len(), iter.len());
+                    let mut vec = Vec::new();
+                    let mut count = 0;
+                    while let Some(el) = iter.next() {
+                        count += 1;
+                        assert_eq!(original.len(), iter.len()+count);
+                        vec.push(el);
+                    }
+                    assert_eq!(original, vec);
                 }
             }
         }

--- a/src/test.rs
+++ b/src/test.rs
@@ -359,5 +359,6 @@ fn simple_line_to() {
 fn line_to_iter() {
     with_pair_test_points(|a: Coordinate, b: Coordinate| {
         assert_eq!(a.line_to(b), a.line_to_iter(b).collect::<Vec<_>>());
+        assert_eq!(a.line_to_lossy(b), a.line_to_lossy_iter(b).collect::<Vec<_>>());
     });
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -402,7 +402,7 @@ fn line_to_with_edge_detection_iter() {
 fn range_iter() {
     with_test_points(|c : Coordinate| {
         for i in &[0, 1, 2, 4, 10, 40]{
-            test_iter(c.range(*i), c.range_iter(*i));
+            test_iter_exact(c.range(*i), c.range_iter(*i));
         }
     });
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -356,9 +356,19 @@ fn simple_line_to() {
 }
 
 // Tests an iterator with size_hint against a Vec
-fn test_iter<T: std::cmp::PartialEq + std::fmt::Debug>(original: Vec<T>, iter: impl Iterator<Item=T>) {
-    assert_eq!(original.len(), iter.size_hint().1.unwrap());
-    assert_eq!(original, iter.collect::<Vec<_>>());
+fn test_iter<T: std::cmp::PartialEq + std::fmt::Debug>(original: Vec<T>, mut iter: impl Iterator<Item=T>) {
+    assert!(original.len() <= iter.size_hint().1.unwrap());
+    assert!(original.len() >= iter.size_hint().0);
+
+    let mut vec = Vec::new();
+    let mut count = 0;
+    while let Some(el) = iter.next() {
+        count += 1;
+        assert!(original.len() <= iter.size_hint().1.unwrap()+count);
+        assert!(original.len() >= iter.size_hint().0+count);
+        vec.push(el);
+    }
+    assert_eq!(original, vec);
 }
 
 // Tests an ExactSizeIterator against a Vec
@@ -384,10 +394,7 @@ fn line_to_iter() {
 #[test]
 fn line_to_lossy_iter() {
     with_pair_test_points(|a: Coordinate, b: Coordinate| {
-        let original = a.line_to_lossy(b);
-        let iter = a.line_to_lossy_iter(b);
-        assert!(original.len() <= iter.size_hint().1.unwrap());
-        assert_eq!(original, iter.collect::<Vec<_>>());
+        test_iter(a.line_to_lossy(b), a.line_to_lossy_iter(b));
     });
 }
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -360,5 +360,6 @@ fn line_to_iter() {
     with_pair_test_points(|a: Coordinate, b: Coordinate| {
         assert_eq!(a.line_to(b), a.line_to_iter(b).collect::<Vec<_>>());
         assert_eq!(a.line_to_lossy(b), a.line_to_lossy_iter(b).collect::<Vec<_>>());
+        assert_eq!(a.line_to_with_edge_detection(b), a.line_to_with_edge_detection_iter(b).collect::<Vec<_>>());
     });
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -358,21 +358,30 @@ fn simple_line_to() {
 #[test]
 fn line_to_iter() {
     with_pair_test_points(|a: Coordinate, b: Coordinate| {
-        assert_eq!(a.line_to(b), a.line_to_iter(b).collect::<Vec<_>>());
+        let original = a.line_to(b);
+        let iter = a.line_to_iter(b);
+        assert_eq!(original.len(), iter.size_hint().1.unwrap());
+        assert_eq!(original, iter.collect::<Vec<_>>());
     });
 }
 
 #[test]
 fn line_to_lossy_iter() {
     with_pair_test_points(|a: Coordinate, b: Coordinate| {
-        assert_eq!(a.line_to_lossy(b), a.line_to_lossy_iter(b).collect::<Vec<_>>());
+        let original = a.line_to_lossy(b);
+        let iter = a.line_to_lossy_iter(b);
+        assert!(original.len() <= iter.size_hint().1.unwrap());
+        assert_eq!(original, iter.collect::<Vec<_>>());
     });
 }
 
 #[test]
 fn line_to_with_edge_detection_iter() {
     with_pair_test_points(|a: Coordinate, b: Coordinate| {
-        assert_eq!(a.line_to_with_edge_detection(b), a.line_to_with_edge_detection_iter(b).collect::<Vec<_>>());
+        let original = a.line_to_with_edge_detection(b);
+        let iter = a.line_to_with_edge_detection_iter(b);
+        assert_eq!(original.len(), iter.size_hint().1.unwrap());
+        assert_eq!(original, iter.collect::<Vec<_>>());
     });
 }
 


### PR DESCRIPTION
Adds iterator versions of line_to*, range and ring, returning Iterator structs.

Tests them against the old versions.

An improvement would  be making size_hint precise for all of them, most should be ExactSizeIterator probably. And I'm not sure if they should implement FusedIterator. For now only Ring has those traits.